### PR TITLE
fix: add fallback for media refresh

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -9,7 +9,7 @@ https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers
 """
 from datetime import timedelta
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 PROJECT_URL = "https://github.com/custom-components/alexa_media_player/"
 ISSUE_URL = "{}issues".format(PROJECT_URL)
 


### PR DESCRIPTION
German users reported that updates were failing and investigation
determined that websockets was missing push information on audio
changes. This adds logic to use other websocket push events to try to
compensate.
However, this is a degraded functionality and results in additional
refresh calls.

Closes #397