### PR TITLE
fix(sensor): return all sensor states as isoformat strings

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -242,7 +242,7 @@ class AlexaMediaSensor(Entity):
     def state(self):
         """Return the state of the sensor."""
         return self._next[self._sensor_property].replace(
-            tzinfo=LOCAL_TIMEZONE) if self._next else STATE_UNAVAILABLE
+            tzinfo=LOCAL_TIMEZONE).isoformat() if self._next else STATE_UNAVAILABLE
 
     @property
     def unit_of_measurement(self):
@@ -352,7 +352,7 @@ class TimerSensor(AlexaMediaSensor):
         return (
             dt.as_local(dt.utc_from_timestamp(
                 dt.utcnow().timestamp() +
-                self._next[self._sensor_property]/1000))
+                self._next[self._sensor_property]/1000)).isoformat()
             if self._next else STATE_UNAVAILABLE)
 
     @property
@@ -386,7 +386,7 @@ class ReminderSensor(AlexaMediaSensor):
         """Return the state of the sensor."""
         return dt.as_local(datetime.datetime.fromtimestamp(
             self._next[self._sensor_property]/1000,
-            tz=LOCAL_TIMEZONE)) if self._next else STATE_UNAVAILABLE
+            tz=LOCAL_TIMEZONE)).isoformat() if self._next else STATE_UNAVAILABLE
 
     @property
     def reminder(self):


### PR DESCRIPTION
This resolves issue #446, which had Safari displaying "Invalid Date"
instead of a proper countdown. The strings were being rendered using
Python's default datetime renderer, which did not put a "T" in between
the day and the hour, as required by ISO-8601 (and Safari's Date()
parser, but not Chrome's)