### PR TITLE
fix: add check for loaded parent

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -415,6 +415,10 @@ class AlexaClient(MediaPlayerDevice):
                         lambda x: (
                             self.hass.data[DATA_ALEXAMEDIA]["accounts"][
                                 self._login.email
+                            ]["entities"]["media_player"].get(x)
+                            and
+                            self.hass.data[DATA_ALEXAMEDIA]["accounts"][
+                                self._login.email
                             ]["entities"]["media_player"][x].state
                             == STATE_PLAYING
                         ),


### PR DESCRIPTION
This addresses a case where the parent group has not been loaded prior to an
update of a child media player.
Closes #496