### PR TITLE
fix: bump alexapy to 1.5.1

### DIFF
--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,7 +9,7 @@
     "alandtse"
   ],
   "requirements": [
-    "alexapy==1.5.0"
+    "alexapy==1.5.1"
   ],
   "homeassistant": "0.96.0"
 }


### PR DESCRIPTION
closes #572