### PR TITLE
fix: catch missing key for switches dictionary

### DIFF
--- a/custom_components/alexa_media/switch.py
+++ b/custom_components/alexa_media/switch.py
@@ -54,11 +54,9 @@ async def async_setup_platform(hass, config, add_devices_callback, discovery_inf
         if key not in (
             hass.data[DATA_ALEXAMEDIA]["accounts"][account]["entities"]["switch"]
         ):
-            (
-                hass.data[DATA_ALEXAMEDIA]["accounts"][account]["entities"]["switch"][
-                    key
-                ]
-            ) = {}
+            hass.data[DATA_ALEXAMEDIA]["accounts"][account]["entities"]["switch"][
+                key
+            ] = {}
             for (switch_key, class_) in SWITCH_TYPES:
                 if (
                     switch_key == "dnd"

--- a/custom_components/alexa_media/switch.py
+++ b/custom_components/alexa_media/switch.py
@@ -60,13 +60,13 @@ async def async_setup_platform(hass, config, add_devices_callback, discovery_inf
             for (switch_key, class_) in SWITCH_TYPES:
                 if (
                     switch_key == "dnd"
-                    and not account_dict["devices"]["switch"][key].get("dnd")
+                    and not account_dict["devices"]["switch"].get(key, {}).get("dnd")
                 ) or (
                     switch_key in ["shuffle", "repeat"]
                     and "MUSIC_SKILL"
-                    not in account_dict["devices"]["media_player"][key].get(
-                        "capabilities"
-                    )
+                    not in account_dict["devices"]["media_player"]
+                    .get(key, {})
+                    .get("capabilities", {})
                 ):
                     _LOGGER.debug(
                         "%s: Skipping %s for %s",

--- a/custom_components/alexa_media/translations
+++ b/custom_components/alexa_media/translations
@@ -1,0 +1,1 @@
+.translations


### PR DESCRIPTION
closes #657 