### PR TITLE
feat: add option for queue_delay

### DIFF
--- a/custom_components/alexa_media/.translations/en.json
+++ b/custom_components/alexa_media/.translations/en.json
@@ -4,7 +4,7 @@
       "connection_error": "Error connecting; check network and retry",
       "identifier_exists": "Email for Alexa URL already registered",
       "invalid_credentials": "Invalid credentials",
-      "unknown_error": "Unknown error, please report with logs"
+      "unknown_error": "Unknown error, please report log info"
     },
     "step": {
       "user": {
@@ -51,5 +51,14 @@
       }
     },
     "title": "Alexa Media Player"
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "queue_delay": "Seconds to wait to queue commands together"
+        }
+      }
+    }
   }
 }

--- a/custom_components/alexa_media/alarm_control_panel.py
+++ b/custom_components/alexa_media/alarm_control_panel.py
@@ -26,6 +26,7 @@ from . import (
     CONF_EMAIL,
     CONF_EXCLUDE_DEVICES,
     CONF_INCLUDE_DEVICES,
+    CONF_QUEUE_DELAY,
     DATA_ALEXAMEDIA,
     DOMAIN as ALEXA_DOMAIN,
     MIN_TIME_BETWEEN_FORCED_SCANS,
@@ -126,6 +127,7 @@ class AlexaAlarmControlPanel(AlarmControlPanel):
         self._login = login
         self.alexa_api = AlexaAPI(self, login)
         self.alexa_api_session = login.session
+        self.email = login.email
         self.account = hide_email(login.email)
 
         # Guard info
@@ -269,7 +271,11 @@ class AlexaAlarmControlPanel(AlarmControlPanel):
         if available_media_players:
             _LOGGER.debug("Sending guard command to: %s", available_media_players[0])
             await available_media_players[0].alexa_api.set_guard_state(
-                self._appliance_id.split("_")[2], command_map[command]
+                self._appliance_id.split("_")[2],
+                command_map[command],
+                queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][self.email][
+                    "options"
+                ][CONF_QUEUE_DELAY],
             )
             await sleep(2)  # delay
         else:

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -29,6 +29,8 @@ from .const import (
     CONF_DEBUG,
     CONF_EXCLUDE_DEVICES,
     CONF_INCLUDE_DEVICES,
+    CONF_QUEUE_DELAY,
+    DEFAULT_QUEUE_DELAY,
     DATA_ALEXAMEDIA,
     DOMAIN,
 )
@@ -390,3 +392,34 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
             },
         )
         return await self._show_form(data_schema=vol.Schema(new_schema))
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a option flow for Alexa Media."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Handle options flow."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_QUEUE_DELAY,
+                    default=self.config_entry.options.get(
+                        CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY
+                    ),
+                ): vol.All(vol.Coerce(float), vol.Clamp(min=0))
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -30,7 +30,11 @@ CONF_ACCOUNTS = "accounts"
 CONF_DEBUG = "debug"
 CONF_INCLUDE_DEVICES = "include_devices"
 CONF_EXCLUDE_DEVICES = "exclude_devices"
+CONF_QUEUE_DELAY = "queue_delay"
 
+DATA_LISTENER = "listener"
+
+DEFAULT_QUEUE_DELAY = 1.5
 SERVICE_CLEAR_HISTORY = "clear_history"
 SERVICE_UPDATE_LAST_CALLED = "update_last_called"
 ATTR_MESSAGE = "message"

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://github.com/custom-components/alexa_media_player/wiki",
   "dependencies": ["configurator"],
   "codeowners": ["@keatontaylor", "@alandtse"],
-  "requirements": ["alexapy==1.6.1"]
+  "requirements": ["alexapy==1.7.0"]
 }

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -44,6 +44,7 @@ from . import (
     CONF_EMAIL,
     CONF_NAME,
     CONF_PASSWORD,
+    CONF_QUEUE_DELAY,
     DATA_ALEXAMEDIA,
     DOMAIN as ALEXA_DOMAIN,
     MIN_TIME_BETWEEN_FORCED_SCANS,
@@ -153,6 +154,7 @@ class AlexaClient(MediaPlayerDevice):
         self.alexa_api = AlexaAPI(self, login)
         self.auth = None
         self.alexa_api_session = login.session
+        self.email = login.email
         self.account = hide_email(login.email)
 
         # Logged in info
@@ -1082,17 +1084,38 @@ class AlexaClient(MediaPlayerDevice):
             )
         elif media_type == "sequence":
             await self.alexa_api.send_sequence(
-                media_id, customer_id=self._customer_id, **kwargs
+                media_id,
+                customer_id=self._customer_id,
+                queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][self.email][
+                    "options"
+                ][CONF_QUEUE_DELAY],
+                **kwargs,
             )
         elif media_type == "routine":
-            await self.alexa_api.run_routine(media_id)
+            await self.alexa_api.run_routine(
+                media_id,
+                queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][self.email][
+                    "options"
+                ][CONF_QUEUE_DELAY],
+            )
         elif media_type == "sound":
             await self.alexa_api.play_sound(
-                media_id, customer_id=self._customer_id, **kwargs
+                media_id,
+                customer_id=self._customer_id,
+                queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][self.email][
+                    "options"
+                ][CONF_QUEUE_DELAY],
+                **kwargs,
             )
         else:
             await self.alexa_api.play_music(
-                media_type, media_id, customer_id=self._customer_id, **kwargs
+                media_type,
+                media_id,
+                customer_id=self._customer_id,
+                queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][self.email][
+                    "options"
+                ][CONF_QUEUE_DELAY],
+                **kwargs,
             )
         if not (
             self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._login.email]["websocket"]

--- a/custom_components/alexa_media/notify.py
+++ b/custom_components/alexa_media/notify.py
@@ -19,7 +19,14 @@ from homeassistant.components.notify import (
     BaseNotificationService,
 )
 
-from . import CONF_EMAIL, DATA_ALEXAMEDIA, DOMAIN, hide_email, hide_serial
+from . import (
+    CONF_EMAIL,
+    CONF_QUEUE_DELAY,
+    DATA_ALEXAMEDIA,
+    DOMAIN,
+    hide_email,
+    hide_serial,
+)
 from .helpers import retry_async
 
 _LOGGER = logging.getLogger(__name__)
@@ -156,23 +163,34 @@ class AlexaNotificationService(BaseNotificationService):
         except ValueError:
             _LOGGER.debug("Invalid Home Assistant entity in %s", entities)
         tasks = []
-        if data["type"] == "tts":
-            targets = self.convert(entities, type_="entities", filter_matches=True)
-            _LOGGER.debug("TTS entities: %s", targets)
-            for alexa in targets:
-                _LOGGER.debug("TTS by %s : %s", alexa, message)
-                tasks.append(alexa.async_send_tts(message))
-        elif data["type"] == "announce":
-            targets = self.convert(entities, type_="serialnumbers", filter_matches=True)
-            _LOGGER.debug(
-                "Announce targets: %s entities: %s",
-                list(map(hide_serial, targets)),
-                entities,
-            )
-            for account, account_dict in self.hass.data[DATA_ALEXAMEDIA][
-                "accounts"
-            ].items():
-                for alexa in account_dict["entities"]["media_player"].values():
+        for account, account_dict in self.hass.data[DATA_ALEXAMEDIA][
+            "accounts"
+        ].items():
+            for alexa in account_dict["entities"]["media_player"].values():
+                if data["type"] == "tts":
+                    targets = self.convert(
+                        entities, type_="entities", filter_matches=True
+                    )
+                    _LOGGER.debug("TTS entities: %s", targets)
+                    if alexa in targets and alexa.available:
+                        _LOGGER.debug("TTS by %s : %s", alexa, message)
+                        tasks.append(
+                            alexa.async_send_tts(
+                                message,
+                                queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][
+                                    self.email
+                                ]["options"][CONF_QUEUE_DELAY],
+                            )
+                        )
+                elif data["type"] == "announce":
+                    targets = self.convert(
+                        entities, type_="serialnumbers", filter_matches=True
+                    )
+                    _LOGGER.debug(
+                        "Announce targets: %s entities: %s",
+                        list(map(hide_serial, targets)),
+                        entities,
+                    )
                     if alexa.unique_id in targets and alexa.available:
                         _LOGGER.debug(
                             ("%s: Announce by %s to " "targets: %s: %s"),
@@ -187,12 +205,25 @@ class AlexaNotificationService(BaseNotificationService):
                                 targets=targets,
                                 title=title,
                                 method=(data["method"] if "method" in data else "all"),
+                                queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][
+                                    self.email
+                                ]["options"][CONF_QUEUE_DELAY],
                             )
                         )
                         break
-        elif data["type"] == "push":
-            targets = self.convert(entities, type_="entities", filter_matches=True)
-            for alexa in targets:
-                _LOGGER.debug("Push by %s : %s %s", alexa, title, message)
-                tasks.append(alexa.async_send_mobilepush(message, title=title))
+                elif data["type"] == "push":
+                    targets = self.convert(
+                        entities, type_="entities", filter_matches=True
+                    )
+                    if alexa in targets and alexa.available:
+                        _LOGGER.debug("Push by %s : %s %s", alexa, title, message)
+                        tasks.append(
+                            alexa.async_send_mobilepush(
+                                message,
+                                title=title,
+                                queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][
+                                    self.email
+                                ]["options"][CONF_QUEUE_DELAY],
+                            )
+                        )
         await asyncio.gather(*tasks)

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -51,5 +51,14 @@
       }
     },
     "title": "Alexa Media Player"
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "queue_delay": "Seconds to wait to queue commands together"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Queue delay controls how long each command will wait to queue up other
commands. This will help reduce `too many requests` errors but will delay
running the command. The default is 1.5 seconds. 0 seconds will result in no
queuing behavior.