### PR TITLE
fix: fix configuration.yaml import code

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -114,15 +114,20 @@ async def async_setup(hass, config, discovery_info=None):
 
     domainconfig = config.get(DOMAIN)
     for account in domainconfig[CONF_ACCOUNTS]:
-        entry_title = "{} - {}".format(account[CONF_EMAIL], account[CONF_URL])
+        entry_found = False
         _LOGGER.debug(
             "Importing config information for %s - %s from configuration.yaml",
             hide_email(account[CONF_EMAIL]),
             account[CONF_URL],
         )
-        if entry_title in configured_instances(hass):
+        if hass.config_entries.async_entries(DOMAIN):
+            _LOGGER.debug("Found existing config entries")
             for entry in hass.config_entries.async_entries(DOMAIN):
-                if entry_title == entry.title:
+                if (
+                    entry.data.get(CONF_EMAIL) == account[CONF_EMAIL]
+                    and entry.data.get(CONF_URL) == account[CONF_URL]
+                ):
+                    _LOGGER.debug("Updating existing entry")
                     hass.config_entries.async_update_entry(
                         entry,
                         data={
@@ -137,8 +142,10 @@ async def async_setup(hass, config, discovery_info=None):
                             ].total_seconds(),
                         },
                     )
+                    entry_found = True
                     break
-        else:
+        if not entry_found:
+            _LOGGER.debug("Creating new config entry")
             hass.async_create_task(
                 hass.config_entries.flow.async_init(
                     DOMAIN,

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -9,7 +9,7 @@ https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers
 """
 from datetime import timedelta
 
-__version__ = "2.5.14"
+__version__ = "2.5.15"
 PROJECT_URL = "https://github.com/custom-components/alexa_media_player/"
 ISSUE_URL = "{}issues".format(PROJECT_URL)
 


### PR DESCRIPTION
The import will now search config entries by data values instead of by title which
can be changed in HA 109. The code also properly creates a new entry
after failing a search.
closes #665
