### PR TITLE
fix: discovery not working

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -32,6 +32,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.util import dt
 import voluptuous as vol
 
@@ -879,6 +880,12 @@ async def setup_alexa(hass, config_entry, login_obj):
             update_interval=timedelta(
                 seconds=scan_interval * 10 if websocket_enabled else scan_interval
             ),
+            request_refresh_debouncer = Debouncer(
+                hass,
+                _LOGGER,
+                10,
+                True,
+            )
         )
     # Fetch initial data so we have data when entities subscribe
     _LOGGER.debug("Refreshing coordinator")


### PR DESCRIPTION
fixes #697 

This is the error that I get during the init phase that prevents to discover my Alexa devices.

```
Sun May 10 2020 17:06:47 GMT+0200 (Central European Summer Time)
Error setting up entry paolo.antinori@gmail.com - amazon.it for alexa_media
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 215, in async_setup
    hass, self
  File "/config/custom_components/alexa_media/__init__.py", line 221, in async_setup_entry
    if await test_login_status(hass, config_entry, login, setup_alexa):
  File "/config/custom_components/alexa_media/configurator.py", line 180, in test_login_status
    await hass.async_add_job(alexa_setup_callback, hass, config_entry, login)
  File "/config/custom_components/alexa_media/__init__.py", line 880, in setup_alexa
    seconds=scan_interval * 10 if websocket_enabled else scan_interval
TypeError: __init__() missing 1 required positional argument: 'request_refresh_debouncer'
Connection lost. Reconnecting…
```

This PR fixes the problem and allows me to find my devices.

I'm getting this on `Home Assistant 0.105.4`