### PR TITLE
feat: add media_stop command

### DIFF
--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://github.com/custom-components/alexa_media_player/wiki",
   "dependencies": ["configurator"],
   "codeowners": ["@keatontaylor", "@alandtse"],
-  "requirements": ["alexapy==1.8.4"]
+  "requirements": ["alexapy==1.9.0"]
 }

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -996,6 +996,25 @@ class AlexaClient(MediaPlayerDevice):
             await self.async_update()
 
     @_catch_login_errors
+    async def async_media_stop(self):
+        """Send stop command."""
+        if not self.available:
+            return
+        if self._playing_parent:
+            await self._playing_parent.async_media_stop()
+        else:
+            await self.alexa_api.stop(
+                customer_id=self._customer_id,
+                queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][self.email][
+                    "options"
+                ][CONF_QUEUE_DELAY],
+            )
+        if not (
+            self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._login.email]["websocket"]
+        ):
+            await self.async_update()
+
+    @_catch_login_errors
     async def async_turn_off(self):
         """Turn the client off.
 


### PR DESCRIPTION
This is the routine Stop Audio command which should stop all audio
including skills and is queueable. Use with `media_player.media_stop`
closes #692