### PR TITLE
feat: add support for canned_tts

### DIFF
--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://github.com/custom-components/alexa_media_player/wiki",
   "dependencies": ["configurator"],
   "codeowners": ["@keatontaylor", "@alandtse"],
-  "requirements": ["alexapy==1.9.0"]
+  "requirements": ["alexapy==1.10.0"]
 }


### PR DESCRIPTION
Canned TTS must begin with `alexa.cannedtts.speak` using the tts notify
mode. This is discovered using [sequence discovery](https://github.com/custom-components/alexa_media_player/wiki/Developers%3A-Sequence-Discovery).
closes #573