### PR TITLE
fix: fix HA warning re deprecated classes

### DIFF
--- a/custom_components/alexa_media/alarm_control_panel.py
+++ b/custom_components/alexa_media/alarm_control_panel.py
@@ -7,12 +7,11 @@ Alexa Devices Alarm Control Panel using Guard Mode.
 For more details about this platform, please refer to the documentation at
 https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers-needed/58639
 """
-import logging
 from asyncio import sleep
+import logging
 from typing import Dict, List, Text  # noqa pylint: disable=unused-import
 
 from homeassistant import util
-from homeassistant.components.alarm_control_panel import AlarmControlPanel
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_DISARMED,
@@ -35,6 +34,14 @@ from . import (
     hide_serial,
 )
 from .helpers import _catch_login_errors, add_devices, retry_async
+
+try:
+    from homeassistant.components.alarm_control_panel import (
+        AlarmControlPanelEntity as AlarmControlPanel,
+    )
+except ImportError:
+    from homeassistant.components.alarm_control_panel import AlarmControlPanel
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -13,7 +13,6 @@ import re
 from typing import List, Text  # noqa pylint: disable=unused-import
 
 from homeassistant import util
-from homeassistant.components.media_player import MediaPlayerDevice
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_MUSIC,
     SUPPORT_NEXT_TRACK,
@@ -55,6 +54,13 @@ from . import (
 )
 from .const import DEPENDENT_ALEXA_COMPONENTS, PLAY_SCAN_INTERVAL
 from .helpers import _catch_login_errors, add_devices, retry_async
+
+try:
+    from homeassistant.components.media_player import (
+        MediaPlayerEntity as MediaPlayerDevice,
+    )
+except ImportError:
+    from homeassistant.components.media_player import MediaPlayerDevice
 
 SUPPORT_ALEXA = (
     SUPPORT_PAUSE

--- a/custom_components/alexa_media/switch.py
+++ b/custom_components/alexa_media/switch.py
@@ -10,7 +10,6 @@ https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers
 import logging
 from typing import List  # noqa pylint: disable=unused-import
 
-from homeassistant.components.switch import SwitchDevice
 from homeassistant.exceptions import ConfigEntryNotReady, NoEntitySpecifiedError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -24,6 +23,11 @@ from . import (
     hide_serial,
 )
 from .helpers import _catch_login_errors, add_devices, retry_async
+
+try:
+    from homeassistant.components.switch import SwitchEntity as SwitchDevice
+except ImportError:
+    from homeassistant.components.switch import SwitchDevice
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes per https://developers.home-assistant.io/blog/2020/05/14/entity-class-names/
closes #699