### PR TITLE
fix: update strings.json to remove title key

### DIFF
--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -60,9 +60,7 @@
       "forgot_password": "The Forgot Password page was detected. This normally is the result of too may failed logins. Amazon may require action before a relogin can be attempted.",
       "login_failed": "Alexa Media Player failed to login.",
       "reauth_successful": "Alexa Media Player successfully reauthenticated."
-    },
-    "title": "Alexa Media Player"
-  },
+    }
   "options": {
     "step": {
       "init": {


### PR DESCRIPTION
got this warrning "Warning: G] [TRANSLATIONS] config.title key has been moved out of config and into the root of strings.json. Starting Home Assistant 0.109 you only need to define this key in the root if the title needs to be different than the name of your integration in the manifest."