### PR TITLE
 fix: bump to alexapy 1.15.2

### DIFF
--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -6,5 +6,5 @@
   "issue_tracker": "https://github.com/custom-components/alexa_media_player/issues",
   "dependencies": ["persistent_notification"],
   "codeowners": ["@keatontaylor", "@alandtse"],
-  "requirements": ["alexapy==1.15.1", "packaging~=20.3", "wrapt~=1.12.1"]
+  "requirements": ["alexapy==1.15.2", "packaging~=20.3", "wrapt~=1.12.1"]
 }


### PR DESCRIPTION
Handle `extra` keyword arg from HA 0.115.4
closes #957 