### PR TITLE
ci: update release variable

### DIFF
--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -55,7 +55,7 @@ jobs:
           zip alexa_media.zip -r ./
       - name: Set release variable
         run: |
-          echo "::set-env name=release_version::`git describe --abbrev=0`"
+          echo "release_version=`git describe --abbrev=0`" >> ${{ github.ref }}
       - name: Sleep
         # add delay so upload does not kill the release notes from semantic-release
         run: |
@@ -66,5 +66,5 @@ jobs:
           repo_token: ${{ secrets.GH_TOKEN }}
           file: /home/runner/work/alexa_media_player/alexa_media_player/custom_components/alexa_media/alexa_media.zip
           asset_name: alexa_media.zip
-          tag: ${{ env.release_version }}
+          tag: ${{ github.ref }}
           overwrite: true


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Signed-off-by: Alan Tse <alandtse@gmail.com>