### PR TITLE
fix: fix target matching for secondary accounts

### DIFF
--- a/custom_components/alexa_media/notify.py
+++ b/custom_components/alexa_media/notify.py
@@ -117,11 +117,17 @@ class AlexaNotificationService(BaseNotificationService):
                 #     hide_serial(alexa.unique_id),
                 #     alexa.entity_id,
                 # )
-                if item in (alexa, alexa.name, alexa.unique_id, alexa.entity_id):
+                if item in (
+                    alexa,
+                    alexa.name,
+                    alexa.unique_id,
+                    alexa.entity_id,
+                    alexa.device_serial_number,
+                ):
                     if type_ == "entities":
                         converted = alexa
                     elif type_ == "serialnumbers":
-                        converted = alexa.unique_id
+                        converted = alexa.device_serial_number
                     elif type_ == "names":
                         converted = alexa.name
                     elif type_ == "entity_ids":


### PR DESCRIPTION
Secondary accounts have a different unique_id so would fail to match
during convert. Add match on device_serial_number.
closes #1116