### PR TITLE
Add device information to notification event

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -210,7 +210,7 @@ class AlexaMediaNotificationSensor(Entity):
         )
         self.hass.bus.async_fire(
             "alexa_media_notification_event",
-            event_data={"email": hide_email(self._account), "event": self._active[0]},
+            event_data={"email": hide_email(self._account), "device": {"name": self._name}, "event": self._active[0]},
         )
 
     def _fix_alarm_date_time(self, value):


### PR DESCRIPTION
Currently it is difficult to understand which device triggered a notification event. This adds the device name which triggered the event