### PR TITLE
fix: check for valid ha url

### DIFF
--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -5,6 +5,7 @@
       "identifier_exists": "Email for Alexa URL already registered",
       "invalid_credentials": "Invalid credentials",
       "2fa_key_invalid": "Invalid Built-In 2FA key",
+      "hass_url_invalid": "Unable to connect to Home Assistant url. Please check the Internal Url under Configuration -> General",
       "unknown_error": "Unknown error, please enable advanced debugging and report log info"
     },
     "step": {

--- a/custom_components/alexa_media/translations/en.json
+++ b/custom_components/alexa_media/translations/en.json
@@ -10,6 +10,7 @@
       "connection_error": "Error connecting; check network and retry",
       "identifier_exists": "Email for Alexa URL already registered",
       "invalid_credentials": "Invalid credentials",
+      "hass_url_invalid": "Unable to connect to Home Assistant url. Please check the Internal Url under Configuration -> General",
       "unknown_error": "Unknown error, please enable advanced debugging and report log info"
     },
     "step": {


### PR DESCRIPTION
The server will now try to connect to the provided HA url. This will
catch basic errors related to the wrong ip addres or port or the use of
https. It will not catch firewall issue which are not detectable from
the server.