### PR TITLE
fix: ignore typerrors for update_last_called

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -606,7 +606,15 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
         to notify listeners.
         """
         if not last_called or not (last_called and last_called.get("summary")):
-            last_called = await AlexaAPI.get_last_device_serial(login_obj)
+            try:
+                last_called = await AlexaAPI.get_last_device_serial(login_obj)
+            except TypeError:
+                _LOGGER.debug(
+                    "%s: Error updating last_called: %s",
+                    hide_email(email),
+                    hide_serial(last_called),
+                )
+                return
         _LOGGER.debug(
             "%s: Updated last_called: %s", hide_email(email), hide_serial(last_called)
         )

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -7,5 +7,5 @@
   "issue_tracker": "https://github.com/custom-components/alexa_media_player/issues",
   "dependencies": ["persistent_notification", "http"],
   "codeowners": ["@keatontaylor", "@alandtse"],
-  "requirements": ["alexapy==1.24.2", "packaging~=20.3", "wrapt~=1.12.1"]
+  "requirements": ["alexapy==1.24.3", "packaging~=20.3", "wrapt~=1.12.1"]
 }


### PR DESCRIPTION
Activites page may return {"message":"Rate exceeded"} with a http 200
message.
closes #1196