### PR TITLE
Support lights and the temperature sensor of the Echo device

### DIFF
--- a/custom_components/alexa_media/alarm_control_panel.py
+++ b/custom_components/alexa_media/alarm_control_panel.py
@@ -146,8 +146,8 @@ class AlexaAlarmControlPanel(AlarmControlPanel, AlexaMedia, CoordinatorEntity):
                 "%s: Guard Discovered %s: %s %s",
                 self.account,
                 self._friendly_name,
-                self._appliance_id,
-                self._guard_entity_id,
+                hide_serial(self._appliance_id),
+                hide_serial(self._guard_entity_id),
             )
 
     @_catch_login_errors
@@ -228,7 +228,8 @@ class AlexaAlarmControlPanel(AlarmControlPanel, AlexaMedia, CoordinatorEntity):
 
     @property
     def assumed_state(self) -> bool:
-        return self._login.session.closed
+        last_refresh_success = self.coordinator.data and self._guard_entity_id in self.coordinator.data
+        return not last_refresh_success
 
     @property
     def device_state_attributes(self):

--- a/custom_components/alexa_media/alarm_control_panel.py
+++ b/custom_components/alexa_media/alarm_control_panel.py
@@ -8,10 +8,9 @@ https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers
 """
 from asyncio import sleep
 import logging
-from typing import Dict, List, Text  # noqa pylint: disable=unused-import
+from typing import Dict, List, Optional, Text  # noqa pylint: disable=unused-import
 
-from alexapy import AlexaAPI, hide_email, hide_serial
-from homeassistant import util
+from alexapy import hide_email, hide_serial
 from homeassistant.const import (
     CONF_EMAIL,
     STATE_ALARM_ARMED_AWAY,
@@ -19,10 +18,9 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.event import async_call_later
-from simplejson import JSONDecodeError
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .alexa_entity import parse_guard_state_from_coordinator
 from .alexa_media import AlexaMedia
 from .const import (
     CONF_EXCLUDE_DEVICES,
@@ -31,8 +29,6 @@ from .const import (
     DATA_ALEXAMEDIA,
     DEFAULT_QUEUE_DELAY,
     DOMAIN as ALEXA_DOMAIN,
-    MIN_TIME_BETWEEN_FORCED_SCANS,
-    MIN_TIME_BETWEEN_SCANS,
 )
 from .helpers import _catch_login_errors, add_devices
 
@@ -75,10 +71,14 @@ async def async_setup_platform(
                 "alarm_control_panel"
             ]
         ) = {}
-    alexa_client: AlexaAlarmControlPanel = AlexaAlarmControlPanel(
-        account_dict["login_obj"], guard_media_players
-    )
-    await alexa_client.init()
+    alexa_client: Optional[AlexaAlarmControlPanel] = None
+    guard_entities = account_dict["alexa_entities"].get("guards", [])
+    if guard_entities:
+        alexa_client = AlexaAlarmControlPanel(
+            account_dict["login_obj"], account_dict["coordinator"], guard_entities[0], guard_media_players
+        )
+    else:
+        _LOGGER.debug("%s: No Alexa Guard entity found", account)
     if not (alexa_client and alexa_client.unique_id):
         _LOGGER.debug(
             "%s: Skipping creation of uninitialized device: %s",
@@ -125,147 +125,30 @@ async def async_unload_entry(hass, entry) -> bool:
     return True
 
 
-class AlexaAlarmControlPanel(AlarmControlPanel, AlexaMedia):
+class AlexaAlarmControlPanel(AlarmControlPanel, AlexaMedia, CoordinatorEntity):
     """Implementation of Alexa Media Player alarm control panel."""
 
-    def __init__(self, login, media_players=None) -> None:
+    def __init__(self, login, coordinator, guard_entity, media_players=None) -> None:
         # pylint: disable=unexpected-keyword-arg
         """Initialize the Alexa device."""
-        super().__init__(None, login)
+        AlexaMedia.__init__(self, None, login)
+        CoordinatorEntity.__init__(self, coordinator)
         _LOGGER.debug("%s: Initiating alarm control panel", hide_email(login.email))
         # AlexaAPI requires a AlexaClient object, need to clean this up
-        self._available = None
-        self._assumed_state = None
 
         # Guard info
-        self._appliance_id = None
-        self._guard_entity_id = None
-        self._friendly_name = "Alexa Guard"
-        self._state = None
-        self._should_poll = False
-        self._attrs: Dict[Text, Text] = {}
+        self._appliance_id = guard_entity["appliance_id"]
+        self._guard_entity_id = guard_entity["id"]
+        self._friendly_name = "Alexa Guard " + self._appliance_id[-5:]
         self._media_players = {} or media_players
-
-    @_catch_login_errors
-    async def init(self):
-        """Initialize."""
-        try:
-
-            data = await self.alexa_api.get_guard_details(self._login)
-            guard_dict = data["locationDetails"]["locationDetails"]["Default_Location"][
-                "amazonBridgeDetails"
-            ]["amazonBridgeDetails"]["LambdaBridge_AAA/OnGuardSmartHomeBridgeService"][
-                "applianceDetails"
-            ][
-                "applianceDetails"
-            ]
-        except (KeyError, TypeError, JSONDecodeError):
-            guard_dict = {}
-        for _, value in guard_dict.items():
-            if value["modelName"] == "REDROCK_GUARD_PANEL":
-                self._appliance_id = value["applianceId"]
-                self._guard_entity_id = value["entityId"]
-                self._friendly_name += " " + self._appliance_id[-5:]
-                _LOGGER.debug(
-                    "%s: Discovered %s: %s %s",
-                    self.account,
-                    self._friendly_name,
-                    self._appliance_id,
-                    self._guard_entity_id,
-                )
-        if not self._appliance_id:
-            _LOGGER.debug("%s: No Alexa Guard entity found", self.account)
-
-    async def async_added_to_hass(self):
-        """Store register state change callback."""
-        try:
-            if not self.enabled:
-                return
-        except AttributeError:
-            pass
-        # Register event handler on bus
-        self._listener = async_dispatcher_connect(
-            self.hass,
-            f"{ALEXA_DOMAIN}_{hide_email(self._login.email)}"[0:32],
-            self._handle_event,
-        )
-        await self.async_update()
-
-    async def async_will_remove_from_hass(self):
-        """Prepare to remove entity."""
-        # Register event handler on bus
-        self._listener()
-
-    def _handle_event(self, event):
-        """Handle websocket events.
-
-        Used instead of polling.
-        """
-        try:
-            if not self.enabled:
-                return
-        except AttributeError:
-            pass
-        if "push_activity" in event:
-            async_call_later(
-                self.hass,
-                2,
-                lambda _: self.hass.async_create_task(
-                    self.async_update(no_throttle=True)
-                ),
-            )
-
-    @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
-    @_catch_login_errors
-    async def async_update(self):
-        """Update Guard state."""
-        try:
-            if not self.enabled:
-                return
-        except AttributeError:
-            pass
-        import json
-
-        if self._login.session.closed:
-            self._available = False
-            self._assumed_state = True
-            return
-        _LOGGER.debug("%s: Refreshing %s", self.account, self.name)
-        state = None
-        state_json = await self.alexa_api.get_guard_state(
-            self._login, self._appliance_id
-        )
-        # _LOGGER.debug("%s: state_json %s", self.account, state_json)
-        if state_json and "deviceStates" in state_json and state_json["deviceStates"]:
-            cap = state_json["deviceStates"][0]["capabilityStates"]
-            # _LOGGER.debug("%s: cap %s", self.account, cap)
-            for item_json in cap:
-                item = json.loads(item_json)
-                # _LOGGER.debug("%s: item %s", self.account, item)
-                if item["name"] == "armState":
-                    state = item["value"]
-                    # _LOGGER.debug("%s: state %s", self.account, state)
-        elif state_json["errors"]:
-            _LOGGER.debug(
-                "%s: Error refreshing alarm_control_panel %s: %s",
+        self._attrs: Dict[Text, Text] = {}
+        _LOGGER.debug(
+                "%s: Guard Discovered %s: %s %s",
                 self.account,
-                self.name,
-                json.dumps(state_json["errors"]) if state_json else None,
+                self._friendly_name,
+                self._appliance_id,
+                self._guard_entity_id,
             )
-        if state is None:
-            self._available = False
-            self._assumed_state = True
-            return
-        if state == "ARMED_AWAY":
-            self._state = STATE_ALARM_ARMED_AWAY
-        elif state == "ARMED_STAY":
-            self._state = STATE_ALARM_DISARMED
-        else:
-            self._state = STATE_ALARM_DISARMED
-        self._available = True
-        self._assumed_state = False
-        _LOGGER.debug("%s: Alarm State: %s", self.account, self.state)
-        self.async_write_ha_state()
 
     @_catch_login_errors
     async def _async_alarm_set(self, command: Text = "", code=None) -> None:
@@ -299,8 +182,7 @@ class AlexaAlarmControlPanel(AlarmControlPanel, AlexaMedia):
             await self.alexa_api.static_set_guard_state(
                 self._login, self._guard_entity_id, command
             )
-        await self.async_update(no_throttle=True)
-        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
 
     async def async_alarm_disarm(self, code=None) -> None:
         # pylint: disable=unexpected-keyword-arg
@@ -325,19 +207,13 @@ class AlexaAlarmControlPanel(AlarmControlPanel, AlexaMedia):
     @property
     def state(self):
         """Return the state of the device."""
-        return self._state
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return self._attrs
-
-    @property
-    def should_poll(self):
-        """Return the polling state."""
-        return self._should_poll or not (
-            self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._login.email]["websocket"]
-        )
+        _state = parse_guard_state_from_coordinator(self.coordinator, self._guard_entity_id)
+        if _state == "ARMED_AWAY":
+            return STATE_ALARM_ARMED_AWAY
+        elif _state == "ARMED_STAY":
+            return STATE_ALARM_DISARMED
+        else:
+            return STATE_ALARM_DISARMED
 
     @property
     def supported_features(self) -> int:
@@ -351,11 +227,10 @@ class AlexaAlarmControlPanel(AlarmControlPanel, AlexaMedia):
         return SUPPORT_ALARM_ARM_AWAY
 
     @property
-    def available(self):
-        """Return the availability of the device."""
-        return self._available
+    def assumed_state(self) -> bool:
+        return self._login.session.closed
 
     @property
-    def assumed_state(self):
-        """Return whether the state is an assumed_state."""
-        return self._assumed_state
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._attrs

--- a/custom_components/alexa_media/alarm_control_panel.py
+++ b/custom_components/alexa_media/alarm_control_panel.py
@@ -72,7 +72,7 @@ async def async_setup_platform(
             ]
         ) = {}
     alexa_client: Optional[AlexaAlarmControlPanel] = None
-    guard_entities = account_dict["alexa_entities"].get("guards", [])
+    guard_entities = account_dict.get("devices", {}).get("guard", [])
     if guard_entities:
         alexa_client = AlexaAlarmControlPanel(
             account_dict["login_obj"], account_dict["coordinator"], guard_entities[0], guard_media_players

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -1,0 +1,142 @@
+"""
+Alexa Devices Sensors.
+
+SPDX-License-Identifier: Apache-2.0
+
+For more details about this platform, please refer to the documentation at
+https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers-needed/58639
+"""
+
+import json
+import logging
+from typing import Any, Dict, Text
+
+from alexapy import AlexaAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def has_capability(appliance: Dict[Text, Any], interface_name: Text, property_name: Text) -> bool:
+    for cap in appliance["capabilities"]:
+        props = cap["properties"]
+        if cap["interfaceName"] == interface_name and (props["retrievable"] or props["proactivelyReported"]):
+            for prop in props["supported"]:
+                if prop["name"] == property_name:
+                    return True
+    return False
+
+
+def is_local(appliance: Dict[Text, Any]) -> bool:
+    # connectedVia is a flag that determines which Echo devices holds the connection. Its blank for
+    # skill derived devices and includes an Echo name for zigbee and local devices. This is used to limit
+    # the scope of what devices will be discovered. This is mainly present to prevent loops with the official Alexa
+    # integration. There is probably a better way to prevent that, but this works.
+    return appliance["connectedVia"]
+
+
+def is_alexa_guard(appliance: Dict[Text, Any]) -> bool:
+    """Is the given appliance the guard alarm system of an echo."""
+    return appliance["modelName"] == "REDROCK_GUARD_PANEL" and has_capability(appliance,
+                                                                              "Alexa.SecurityPanelController",
+                                                                              "armState")
+
+
+def is_temperature_sensor(appliance: Dict[Text, Any]) -> bool:
+    """Is the given appliance the temperature sensor of an Echo."""
+    return is_local(appliance) and appliance["manufacturerName"] == "Amazon" and has_capability(appliance,
+                                                                                                "Alexa.TemperatureSensor",
+                                                                                                "temperature")
+
+
+def is_light(appliance: Dict[Text, Any]) -> bool:
+    """Is the given appliance a light controlled locally by an Echo."""
+    return is_local(appliance) and "LIGHT" in appliance["applianceTypes"] and has_capability(appliance,
+                                                                                             "Alexa.PowerController",
+                                                                                             "powerState")
+
+def get_friendliest_name(appliance: Dict[Text, Any]) -> Text:
+    """Find the best friendly name. Alexa seems to store manual renames in aliases. Prefer that one."""
+    aliases = appliance.get("aliases", [])
+    for alias in aliases:
+        friendly = alias.get("friendlyName")
+        if friendly:
+            return friendly
+    return appliance["friendlyName"]
+
+def parse_alexa_entities(network_details):
+    """Turn the network details into a list of useful entities with the important details extracted."""
+    lights = []
+    guards = []
+    temperature_sensors = []
+    location_details = network_details["locationDetails"]["locationDetails"]
+    for location in location_details.values():
+        amazon_bridge_details = location["amazonBridgeDetails"]["amazonBridgeDetails"]
+        for bridge in amazon_bridge_details.values():
+            appliance_details = bridge["applianceDetails"]["applianceDetails"]
+            for appliance in appliance_details.values():
+                processed_appliance = {
+                    "id": appliance["entityId"],
+                    "appliance_id": appliance["applianceId"],
+                    "name": get_friendliest_name(appliance)
+                }
+                if is_alexa_guard(appliance):
+                    guards.append(processed_appliance)
+                elif is_temperature_sensor(appliance):
+                    temperature_sensors.append(processed_appliance)
+                elif is_light(appliance):
+                    processed_appliance["brightness"] = has_capability(appliance, "Alexa.BrightnessController", "brightness")
+                    processed_appliance["color"] = has_capability(appliance, "Alexa.ColorController", "color")
+                    processed_appliance["color_temperature"] = has_capability(appliance, "Alexa.ColorTemperatureController",
+                                                                              "colorTemperatureInKelvin")
+                    lights.append(processed_appliance)
+
+    return {
+        "lights": lights,
+        "guards": guards,
+        "temperature_sensors": temperature_sensors
+    }
+
+
+async def get_entity_data(login_obj, entity_ids):
+    """Get and process the entity data into a more usable format."""
+    raw = await AlexaAPI.get_entity_state(login_obj, entity_ids=entity_ids)
+    entities = {}
+    device_states = raw.get("deviceStates")
+    if device_states:
+        for device_state in device_states:
+            entity_id = device_state["entity"]["entityId"]
+            entities[entity_id] = []
+            for cap_state in device_state["capabilityStates"]:
+                entities[entity_id].append(json.loads(cap_state))
+    return entities
+
+
+def parse_temperature_from_coordinator(coordinator, entity_id):
+    """Get the temperature of an entity from the coordinator data."""
+    value = parse_value_from_coordinator(coordinator, entity_id, "Alexa.TemperatureSensor", "temperature")
+    return value.get("value") if value and "value" in value else None
+
+
+def parse_brightness_from_coordinator(coordinator, entity_id):
+    """Get the brightness in the range 0-100."""
+    return parse_value_from_coordinator(coordinator, entity_id, "Alexa.BrightnessController", "brightness")
+
+
+def parse_power_from_coordinator(coordinator, entity_id):
+    """Get the power state of the entity."""
+    return parse_value_from_coordinator(coordinator, entity_id, "Alexa.PowerController", "powerState")
+
+
+def parse_guard_state_from_coordinator(coordinator, entity_id):
+    """Get the guard state from the coordinator data."""
+    return parse_value_from_coordinator(coordinator, entity_id, "Alexa.SecurityPanelController", "armState")
+
+
+def parse_value_from_coordinator(coordinator, entity_id, namespace, name):
+    if coordinator.data and entity_id in coordinator.data:
+        for capState in coordinator.data[entity_id]:
+            if capState.get("namespace") == namespace and capState.get("name") == name:
+                return capState.get("value")
+    else:
+        _LOGGER.debug("Coordinator has no data for %s", entity_id)
+    return None

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -46,6 +46,7 @@ from .const import (
     CONF_COOKIES_TXT,
     CONF_DEBUG,
     CONF_EXCLUDE_DEVICES,
+    CONF_EXTENDED_ENTITY_DISCOVERY,
     CONF_HASS_URL,
     CONF_INCLUDE_DEVICES,
     CONF_OAUTH,
@@ -56,6 +57,7 @@ from .const import (
     CONF_SECURITYCODE,
     CONF_TOTP_REGISTER,
     DATA_ALEXAMEDIA,
+    DEFAULT_EXTENDED_ENTITY_DISCOVERY,
     DEFAULT_QUEUE_DELAY,
     DOMAIN,
     HTTP_COOKIE_HEADER,
@@ -1025,7 +1027,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     default=self.config_entry.options.get(
                         CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY
                     ),
-                ): vol.All(vol.Coerce(float), vol.Clamp(min=0))
+                ): vol.All(vol.Coerce(float), vol.Clamp(min=0)),
+                vol.Required(
+                    CONF_EXTENDED_ENTITY_DISCOVERY,
+                    default=self.config_entry.options.get(
+                        CONF_EXTENDED_ENTITY_DISCOVERY, DEFAULT_EXTENDED_ENTITY_DISCOVERY
+                    )
+                ): bool
             }
         )
         return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -23,7 +23,7 @@ MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
 ALEXA_COMPONENTS = [
     "media_player",
 ]
-DEPENDENT_ALEXA_COMPONENTS = ["notify", "switch", "sensor", "alarm_control_panel"]
+DEPENDENT_ALEXA_COMPONENTS = ["notify", "switch", "sensor", "alarm_control_panel", "light"]
 
 HTTP_COOKIE_HEADER = "# HTTP Cookie File"
 CONF_ACCOUNTS = "accounts"
@@ -33,6 +33,7 @@ CONF_HASS_URL = "hass_url"
 CONF_INCLUDE_DEVICES = "include_devices"
 CONF_EXCLUDE_DEVICES = "exclude_devices"
 CONF_QUEUE_DELAY = "queue_delay"
+CONF_EXTENDED_ENTITY_DISCOVERY = "extended_entity_discovery"
 CONF_SECURITYCODE = "securitycode"
 CONF_OTPSECRET = "otp_secret"
 CONF_PROXY = "proxy"
@@ -43,6 +44,7 @@ DATA_LISTENER = "listener"
 
 EXCEPTION_TEMPLATE = "An exception of type {0} occurred. Arguments:\n{1!r}"
 
+DEFAULT_EXTENDED_ENTITY_DISCOVERY = False
 DEFAULT_QUEUE_DELAY = 1.5
 SERVICE_CLEAR_HISTORY = "clear_history"
 SERVICE_UPDATE_LAST_CALLED = "update_last_called"

--- a/custom_components/alexa_media/light.py
+++ b/custom_components/alexa_media/light.py
@@ -1,0 +1,138 @@
+"""
+Alexa Devices Sensors.
+
+SPDX-License-Identifier: Apache-2.0
+
+For more details about this platform, please refer to the documentation at
+https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers-needed/58639
+"""
+import asyncio
+import datetime
+import logging
+from typing import Callable, List, Optional, Text  # noqa pylint: disable=unused-import
+
+from alexapy import AlexaAPI
+from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import (
+    CONF_EMAIL,
+    CONF_EXCLUDE_DEVICES,
+    CONF_INCLUDE_DEVICES,
+    DATA_ALEXAMEDIA,
+    hide_email,
+)
+from .alexa_entity import (
+    parse_brightness_from_coordinator,
+    parse_power_from_coordinator,
+)
+from .const import CONF_EXTENDED_ENTITY_DISCOVERY
+from .helpers import add_devices
+
+_LOGGER = logging.getLogger(__name__)
+
+LOCAL_TIMEZONE = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinfo
+
+
+async def async_setup_platform(hass, config, add_devices_callback, discovery_info=None):
+    """Set up the Alexa sensor platform."""
+    devices: List[Light] = []
+    account = config[CONF_EMAIL] if config else discovery_info["config"][CONF_EMAIL]
+    account_dict = hass.data[DATA_ALEXAMEDIA]["accounts"][account]
+    include_filter = config.get(CONF_INCLUDE_DEVICES, [])
+    exclude_filter = config.get(CONF_EXCLUDE_DEVICES, [])
+    coordinator = account_dict["coordinator"]
+
+    light_entities = account_dict["alexa_entities"].get("lights", [])
+    if light_entities and account_dict["options"].get(CONF_EXTENDED_ENTITY_DISCOVERY):
+        for le in light_entities:
+            _LOGGER.debug("Creating entity %s for a light with name %s", le["id"], le["name"])
+            light = AlexaLight(coordinator, account_dict["login_obj"], le)
+            account_dict["entities"]["light"].append(light)
+            devices.append(light)
+
+    if devices:
+        await coordinator.async_request_refresh()
+
+    return await add_devices(
+        hide_email(account),
+        devices,
+        add_devices_callback,
+        include_filter,
+        exclude_filter,
+    )
+
+
+async def async_setup_entry(hass, config_entry, async_add_devices):
+    """Set up the Alexa sensor platform by config_entry."""
+    return await async_setup_platform(
+        hass, config_entry.data, async_add_devices, discovery_info=None
+    )
+
+
+async def async_unload_entry(hass, entry) -> bool:
+    """Unload a config entry."""
+    account = entry.data[CONF_EMAIL]
+    account_dict = hass.data[DATA_ALEXAMEDIA]["accounts"][account]
+    _LOGGER.debug("Attempting to unload lights")
+    for light in account_dict["entities"]["light"]:
+        await light.async_remove()
+    return True
+
+
+def ha_brightness_to_alexa(ha):
+    return ha / 255 * 100
+
+
+def alexa_brightness_to_ha(alexa):
+    return alexa / 100 * 255
+
+
+class AlexaLight(CoordinatorEntity, Light):
+    """A temperature sensor reported by an Echo. """
+
+    def __init__(self, coordinator, login, details):
+        super().__init__(coordinator)
+        self.alexa_entity_id = details["id"]
+        self._name = details["name"]
+        self._login = login
+        self._supported_features = SUPPORT_BRIGHTNESS if details["brightness"] else 0
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def unique_id(self):
+        return self.alexa_entity_id
+
+    @property
+    def supported_features(self):
+        return self._supported_features
+
+    @property
+    def is_on(self):
+        return parse_power_from_coordinator(self.coordinator, self.alexa_entity_id) == "ON"
+
+    @property
+    def brightness(self):
+        bright = parse_brightness_from_coordinator(self.coordinator, self.alexa_entity_id)
+        return alexa_brightness_to_ha(bright) if bright is not None else 255
+
+    @staticmethod
+    async def _wait_for_lights():
+        await asyncio.sleep(2)
+
+    async def async_turn_on(self, **kwargs):
+        if self._supported_features & SUPPORT_BRIGHTNESS:
+            bright = ha_brightness_to_alexa(kwargs.get(ATTR_BRIGHTNESS, 255))
+            await AlexaAPI.set_light_state(self._login, self.alexa_entity_id, power_on=True, brightness=bright)
+        else:
+            await AlexaAPI.set_light_state(self._login, self.alexa_entity_id, power_on=True)
+        await self._wait_for_lights()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        await AlexaAPI.set_light_state(self._login, self.alexa_entity_id, power_on=False)
+        await self._wait_for_lights()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/alexa_media/light.py
+++ b/custom_components/alexa_media/light.py
@@ -43,7 +43,7 @@ async def async_setup_platform(hass, config, add_devices_callback, discovery_inf
     exclude_filter = config.get(CONF_EXCLUDE_DEVICES, [])
     coordinator = account_dict["coordinator"]
 
-    light_entities = account_dict["alexa_entities"].get("lights", [])
+    light_entities = account_dict.get("devices", {}).get("light", [])
     if light_entities and account_dict["options"].get(CONF_EXTENDED_ENTITY_DISCOVERY):
         for le in light_entities:
             _LOGGER.debug("Creating entity %s for a light with name %s", hide_serial(le["id"]), le["name"])

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -13,12 +13,14 @@ from typing import Callable, List, Optional, Text  # noqa pylint: disable=unused
 from homeassistant.const import (
     DEVICE_CLASS_TIMESTAMP,
     STATE_UNAVAILABLE,
+    TEMP_CELSIUS,
     __version__ as HA_VERSION,
 )
 from homeassistant.exceptions import ConfigEntryNotReady, NoEntitySpecifiedError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt
 from packaging import version
 import pytz
@@ -32,7 +34,12 @@ from . import (
     hide_email,
     hide_serial,
 )
-from .const import RECURRING_PATTERN, RECURRING_PATTERN_ISO_SET
+from .alexa_entity import parse_temperature_from_coordinator
+from .const import (
+    CONF_EXTENDED_ENTITY_DISCOVERY,
+    RECURRING_PATTERN,
+    RECURRING_PATTERN_ISO_SET,
+)
 from .helpers import add_devices, retry_async
 
 _LOGGER = logging.getLogger(__name__)
@@ -106,14 +113,19 @@ async def async_setup_platform(hass, config, add_devices_callback, discovery_inf
                     hide_email(account),
                     alexa_client,
                 )
+
+    temperature_sensors = []
+    temperature_entities = account_dict["alexa_entities"].get("temperature_sensors", [])
+    if temperature_entities and account_dict["options"].get(CONF_EXTENDED_ENTITY_DISCOVERY):
+        temperature_sensors = await create_temperature_sensors(account_dict, temperature_entities)
+
     return await add_devices(
         hide_email(account),
-        devices,
+        devices + temperature_sensors,
         add_devices_callback,
         include_filter,
         exclude_filter,
     )
-
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
     """Set up the Alexa sensor platform by config_entry."""
@@ -131,7 +143,74 @@ async def async_unload_entry(hass, entry) -> bool:
         for device in sensors[key].values():
             _LOGGER.debug("Removing %s", device)
             await device.async_remove()
+    for temp in account_dict["entities"]["temperature"]:
+        await temp.async_remove()
     return True
+
+
+async def create_temperature_sensors(account_dict, temperature_entities):
+    devices = []
+    coordinator = account_dict["coordinator"]
+    for temp in temperature_entities:
+        _LOGGER.debug("Creating entity %s for a temperature sensor with name %s", temp["id"], temp["name"])
+        sensor = TemperatureSensor(coordinator, temp["id"], temp["name"], lookup_device_info(account_dict, temp["name"]))
+        account_dict["entities"]["temperature"].append(sensor)
+        devices.append(sensor)
+        await coordinator.async_request_refresh()
+    return devices
+
+
+def lookup_device_info(account_dict, name):
+    """Get an assumed device id for an Echo based entirely on the name of the echo.
+
+        This is a bit of guess doing things this way.
+        However, it seems like its probably accurate and there isn't a better way I can find.
+        The alternative is not linking the temperature sensor to the device. That looks half-baked in the dashboard.
+    """
+    for mp in account_dict["entities"]["media_player"].values():
+        if mp.name == name and mp.device_info and "identifiers" in mp.device_info:
+            for ident in mp.device_info["identifiers"]:
+                _LOGGER.debug("Found matching media player(%s) for temperature sensor by name %s. Linking to it.", ident, name)
+                return ident
+    return None
+
+
+class TemperatureSensor(CoordinatorEntity):
+    """A temperature sensor reported by an Echo. """
+
+    def __init__(self, coordinator, entity_id, name, media_player_device_id):
+        super().__init__(coordinator)
+        self.alexa_entity_id = entity_id
+        self._name = name
+        self._media_player_device_id = media_player_device_id
+
+    @property
+    def name(self):
+        return self._name + " Temperature"
+
+    @property
+    def device_info(self):
+        """Return the device_info of the device."""
+        if self._media_player_device_id:
+            return {
+                "identifiers": {self._media_player_device_id},
+                "via_device": self._media_player_device_id,
+            }
+        return None
+
+    @property
+    def unit_of_measurement(self):
+        return TEMP_CELSIUS
+
+    @property
+    def state(self):
+        return parse_temperature_from_coordinator(self.coordinator, self.alexa_entity_id)
+
+    @property
+    def unique_id(self):
+        # This includes "_temperature" because the Alexa entityId is for a physical device
+        # A single physical device could have multiple HA entities
+        return self.alexa_entity_id + "_temperature"
 
 
 class AlexaMediaNotificationSensor(Entity):

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -103,7 +103,8 @@
     "step": {
       "init": {
         "data": {
-          "queue_delay": "Seconds to wait to queue commands together"
+          "queue_delay": "Seconds to wait to queue commands together",
+          "extended_entity_discovery": "Include devices connected via Echo"
         }
       }
     }

--- a/custom_components/alexa_media/translations/en.json
+++ b/custom_components/alexa_media/translations/en.json
@@ -105,7 +105,8 @@
     "step": {
       "init": {
         "data": {
-          "queue_delay": "Seconds to wait to queue commands together"
+          "queue_delay": "Seconds to wait to queue commands together",
+          "extended_entity_discovery": "Include devices connected via Echo"
         }
       }
     }


### PR DESCRIPTION
Closes #1237 and #1202.

This moves all of the phoenix calls being done by the alarm platform into the data update coordinator so that sensor/light platform can share. This involved refactoring of the guard code.

Device support intentionally excludes all Skill-based devices Alexa has access to as there is likely another Home Assistant integration that can better address those items. The light support is quite limited supporting only brightness and power state. Temperature sensor support is complete, but is restricted specifically to the sensor built-in to an Echo.

With the exception of the new guard code, everything should be hidden by a new option. Enabling this feature requires turning that option on and reloading the integration.

I assume there are likely changes needed here. In particular, I wasn't sure on the process for translations. I saw the other languages, but I don't speak them. Should I run my text through Google translate? I'm also completely new to coding for home assistant and struggled with the appropriate way to hide this behind an option. Its definitely hidden, but the "reload the component" step feels like I'm missing some obvious way to do this better.