### PR TITLE
Detect and ignore lights created by emulated_hue

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -44,7 +44,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt, slugify
 import voluptuous as vol
 
-from .alexa_entity import get_entity_data, parse_alexa_entities, AlexaEntityData
+from .alexa_entity import AlexaEntityData, get_entity_data, parse_alexa_entities
 from .config_flow import in_progess_instances
 from .const import (
     ALEXA_COMPONENTS,

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -41,12 +41,11 @@ def has_capability(
     return False
 
 
-def is_emulated_hue(appliance: Dict[Text, Any]) -> bool:
-    """Determine if an appliance may have originated from an emulated hue hub.
+def is_hue_v1(appliance: Dict[Text, Any]) -> bool:
+    """Determine if an appliance is managed via the Philips Hue v1 Hub.
 
-    This check will catch all emulated_hue devices, but it may also catch too much.
-    Its possible some older Hue bulbs may actually use this manufacturer name even though modern bulbs report "Philips".
-    Therefore, only believe this check if emulated_hue is actually turned on.
+    This check catches old Philips Hue bulbs and hubs, but critically, it also catches things pretending to be older
+    Philips Hue bulbs and hubs. This includes things exposed by HA to Alexa using the emulated_hue integration.
     """
     return appliance.get("manufacturerName") == "Royal Philips Electronics"
 
@@ -112,7 +111,7 @@ class AlexaEntity(TypedDict):
     id: Text
     appliance_id: Text
     name: Text
-    is_possibly_emulated: bool
+    is_hue_v1: bool
 
 
 class AlexaLightEntity(AlexaEntity):
@@ -152,7 +151,7 @@ def parse_alexa_entities(network_details: Optional[Dict[Text, Any]]) -> AlexaEnt
                     "id": appliance["entityId"],
                     "appliance_id": appliance["applianceId"],
                     "name": get_friendliest_name(appliance),
-                    "is_possibly_emulated": is_emulated_hue(appliance),
+                    "is_hue_v1": is_hue_v1(appliance),
                 }
                 if is_alexa_guard(appliance):
                     guards.append(processed_appliance)

--- a/custom_components/alexa_media/light.py
+++ b/custom_components/alexa_media/light.py
@@ -12,7 +12,11 @@ import logging
 from typing import Callable, List, Optional, Text  # noqa pylint: disable=unused-import
 
 from alexapy import AlexaAPI, hide_serial
-from homeassistant.components.light import ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, Light
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    SUPPORT_BRIGHTNESS,
+    LightEntity,
+)
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import (
@@ -36,20 +40,23 @@ LOCAL_TIMEZONE = datetime.datetime.now(datetime.timezone.utc).astimezone().tzinf
 
 async def async_setup_platform(hass, config, add_devices_callback, discovery_info=None):
     """Set up the Alexa sensor platform."""
-    devices: List[Light] = []
+    devices: List[LightEntity] = []
     account = config[CONF_EMAIL] if config else discovery_info["config"][CONF_EMAIL]
     account_dict = hass.data[DATA_ALEXAMEDIA]["accounts"][account]
     include_filter = config.get(CONF_INCLUDE_DEVICES, [])
     exclude_filter = config.get(CONF_EXCLUDE_DEVICES, [])
     coordinator = account_dict["coordinator"]
-
+    hue_emulated_enabled = "emulated_hue" in hass.config.as_dict().get("components", set())
     light_entities = account_dict.get("devices", {}).get("light", [])
     if light_entities and account_dict["options"].get(CONF_EXTENDED_ENTITY_DISCOVERY):
         for le in light_entities:
-            _LOGGER.debug("Creating entity %s for a light with name %s", hide_serial(le["id"]), le["name"])
-            light = AlexaLight(coordinator, account_dict["login_obj"], le)
-            account_dict["entities"]["light"].append(light)
-            devices.append(light)
+            if not (le["is_possibly_emulated"] and hue_emulated_enabled):
+                _LOGGER.debug("Creating entity %s for a light with name %s", hide_serial(le["id"]), le["name"])
+                light = AlexaLight(coordinator, account_dict["login_obj"], le)
+                account_dict["entities"]["light"].append(light)
+                devices.append(light)
+            else:
+                _LOGGER.debug("Light '%s' has not been added because it may originate from emulated_hue", le["name"])
 
     if devices:
         await coordinator.async_refresh()
@@ -88,7 +95,7 @@ def alexa_brightness_to_ha(alexa):
     return alexa / 100 * 255
 
 
-class AlexaLight(CoordinatorEntity, Light):
+class AlexaLight(CoordinatorEntity, LightEntity):
     """A temperature sensor reported by an Echo. """
 
     def __init__(self, coordinator, login, details):

--- a/custom_components/alexa_media/light.py
+++ b/custom_components/alexa_media/light.py
@@ -50,7 +50,7 @@ async def async_setup_platform(hass, config, add_devices_callback, discovery_inf
     light_entities = account_dict.get("devices", {}).get("light", [])
     if light_entities and account_dict["options"].get(CONF_EXTENDED_ENTITY_DISCOVERY):
         for le in light_entities:
-            if not (le["is_possibly_emulated"] and hue_emulated_enabled):
+            if not (le["is_hue_v1"] and hue_emulated_enabled):
                 _LOGGER.debug("Creating entity %s for a light with name %s", hide_serial(le["id"]), le["name"])
                 light = AlexaLight(coordinator, account_dict["login_obj"], le)
                 account_dict["entities"]["light"].append(light)
@@ -96,7 +96,7 @@ def alexa_brightness_to_ha(alexa):
 
 
 class AlexaLight(CoordinatorEntity, LightEntity):
-    """A temperature sensor reported by an Echo. """
+    """A light controlled by an Echo. """
 
     def __init__(self, coordinator, login, details):
         super().__init__(coordinator)


### PR DESCRIPTION
Fixes #1251. This should do a reasonable job of ignoring lights that originated at emulated_hue. Sadly, after much testing Alexa eventually had my real Hue bulb and the emulated hue bulb identical in every way except manufacturer name.

I'll document the restriction that older Hue bulbs may be ignored if you have emulated_hue enabled.