### PR TITLE
Automatically reload the integration when extended entity discovery is enabled

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1186,6 +1186,7 @@ async def update_listener(hass, config_entry):
     """Update when config_entry options update."""
     account = config_entry.data
     email = account.get(CONF_EMAIL)
+    reload_needed: bool = False
     for key, old_value in hass.data[DATA_ALEXAMEDIA]["accounts"][email][
         "options"
     ].items():
@@ -1198,9 +1199,10 @@ async def update_listener(hass, config_entry):
                 old_value,
                 hass.data[DATA_ALEXAMEDIA]["accounts"][email]["options"][key],
             )
-
-            if key == CONF_EXTENDED_ENTITY_DISCOVERY and new_value:
-                await hass.config_entries.async_reload(config_entry.entry_id)
+            if key == CONF_EXTENDED_ENTITY_DISCOVERY:
+                reload_needed = True
+    if reload_needed:
+        await hass.config_entries.async_reload(config_entry.entry_id)
 
 
 async def test_login_status(hass, config_entry, login) -> bool:

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1199,6 +1199,9 @@ async def update_listener(hass, config_entry):
                 hass.data[DATA_ALEXAMEDIA]["accounts"][email]["options"][key],
             )
 
+            if key == CONF_EXTENDED_ENTITY_DISCOVERY and new_value:
+                await hass.config_entries.async_reload(config_entry.entry_id)
+
 
 async def test_login_status(hass, config_entry, login) -> bool:
     """Test the login status and spawn requests for info."""


### PR DESCRIPTION
As the title says, simplify the experience by auto-reloading. I'll update wiki when this merges.