### PR TITLE
Alarm state on startup instead of on first refresh

### DIFF
--- a/custom_components/alexa_media/light.py
+++ b/custom_components/alexa_media/light.py
@@ -101,9 +101,6 @@ async def async_setup_platform(hass, config, add_devices_callback, discovery_inf
                     le["name"],
                 )
 
-    if devices:
-        await coordinator.async_refresh()
-
     return await add_devices(
         hide_email(account),
         devices,

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -166,7 +166,6 @@ async def create_temperature_sensors(account_dict, temperature_entities):
         account_dict["entities"]["sensor"].setdefault(serial, {})
         account_dict["entities"]["sensor"][serial]["Temperature"] = sensor
         devices.append(sensor)
-        await coordinator.async_request_refresh()
     return devices
 
 


### PR DESCRIPTION
Fixes #1289 by forcing all entity state to be gathered during network discovery discovery.

Previously, each platform forced a refresh on the coordinator. This was slow and error prone. Now, when the network is discovered full entity state is discovered as well.