### PR TITLE
fix: parse timezone from timestamp

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 For more details about this platform, please refer to the documentation at
 https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers-needed/58639
 """
-from datetime import datetime, timezone
+from datetime import datetime
 import json
 import logging
 import re
@@ -324,8 +324,8 @@ def is_cap_state_still_acceptable(
         if formatted_time_of_sample:
             try:
                 time_of_sample = datetime.strptime(
-                    formatted_time_of_sample, "%Y-%m-%dT%H:%M:%S.%fZ"
-                ).replace(tzinfo=timezone.utc)
+                    formatted_time_of_sample, "%Y-%m-%dT%H:%M:%S.%f%z"
+                )
                 return time_of_sample >= since
             except ValueError:
                 pass


### PR DESCRIPTION
This relies on pulling the timestamp from the string instead of defaulting to UTC
closes #1350