### PR TITLE
fix: fix conversion of aiohttp cookie to httpx

### DIFF
--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -380,10 +380,8 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         )
         if self.login.lastreq:
             self.proxy.last_resp = self.login.lastreq
-            self.proxy.session.cookie_jar.update_cookies(
-                self.login._session.cookie_jar.filter_cookies(
-                    self.proxy._host_url.with_path("/")
-                )
+            self.proxy.session.cookies = self.login._session.cookie_jar.filter_cookies(
+                self.proxy._host_url.with_path("/")
             )
             proxy_url = (
                 self.proxy.access_url().with_path(AUTH_PROXY_PATH) / "resume"


### PR DESCRIPTION
This fixes the case of switching from legacy to proxy login method.

closes #1418
closes #1318 