### PR TITLE
fix: require 2021.12.0

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_poll",
   "zip_release": true,
   "filename": "alexa_media.zip",
-  "homeassistant": "0.106.0"
+  "homeassistant": "2021.12.0"
 }


### PR DESCRIPTION
Due to changes in aiohttp dependency in HA and alexa_media, need to bump
the HA requirement.

closes #1434