### PR TITLE
Add entity_category to the AlexaMediaSwitches

### DIFF
--- a/custom_components/alexa_media/switch.py
+++ b/custom_components/alexa_media/switch.py
@@ -311,6 +311,11 @@ class DNDSwitch(AlexaMediaSwitch):
         """Return the icon of the switch."""
         return super()._icon("mdi:minus-circle", "mdi:minus-circle-off")
 
+    @property
+    def entity_category(self):
+        """Return the entity category of the switch."""
+        return "config"
+
     def _handle_event(self, event):
         """Handle events."""
         try:
@@ -347,6 +352,10 @@ class ShuffleSwitch(AlexaMediaSwitch):
         """Return the icon of the switch."""
         return super()._icon("mdi:shuffle", "mdi:shuffle-disabled")
 
+    @property
+    def entity_category(self):
+        """Return the entity category of the switch."""
+        return "config"
 
 class RepeatSwitch(AlexaMediaSwitch):
     """Representation of a Alexa Media Repeat switch."""
@@ -360,3 +369,8 @@ class RepeatSwitch(AlexaMediaSwitch):
     def icon(self):
         """Return the icon of the switch."""
         return super()._icon("mdi:repeat", "mdi:repeat-off")
+
+    @property
+    def entity_category(self):
+        """Return the entity category of the switch."""
+        return "config"


### PR DESCRIPTION
In a recent release, HA added the concept of entity categories, distinguishing between primary, configuration, diagnostic, and system entities.

This PR just tags the relevant AlexaMediaSwitches as config entities (since they modify configurable toggles rather than primary media player functionality (DND, Shuffle, Repeat). This shouldn't have any substantial impact other than cleaning up some of the auto-generated HA dashboards, and how things are visualized in the UI. I think it will also allow these switches to be filtered in templates if users only want to flip "primary" switches and not configuration switches in an area.

Some additional docs on this are available here:
Release Announcement: https://www.home-assistant.io/blog/2021/11/03/release-202111/
Developer Blog: https://developers.home-assistant.io/blog/2021/10/26/config-entity/#entity-categories
Entity Properties docs: https://developers.home-assistant.io/docs/core/entity/#generic-properties