### PR TITLE
Use EntityCategory enum instead of strings

### DIFF
--- a/custom_components/alexa_media/switch.py
+++ b/custom_components/alexa_media/switch.py
@@ -11,6 +11,7 @@ from typing import List, Text  # noqa pylint: disable=unused-import
 
 from homeassistant.exceptions import ConfigEntryNotReady, NoEntitySpecifiedError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import EntityCategory
 
 from . import (
     CONF_EMAIL,
@@ -314,7 +315,7 @@ class DNDSwitch(AlexaMediaSwitch):
     @property
     def entity_category(self):
         """Return the entity category of the switch."""
-        return "config"
+        return EntityCategory.CONFIG 
 
     def _handle_event(self, event):
         """Handle events."""
@@ -355,7 +356,7 @@ class ShuffleSwitch(AlexaMediaSwitch):
     @property
     def entity_category(self):
         """Return the entity category of the switch."""
-        return "config"
+        return EntityCategory.CONFIG 
 
 class RepeatSwitch(AlexaMediaSwitch):
     """Representation of a Alexa Media Repeat switch."""
@@ -373,4 +374,4 @@ class RepeatSwitch(AlexaMediaSwitch):
     @property
     def entity_category(self):
         """Return the entity category of the switch."""
-        return "config"
+        return EntityCategory.CONFIG 


### PR DESCRIPTION
Specifying the entity category as a string doesn't work anymore starting in `2022.4`, you must use the `EntityCategory` enum instead. This fixes #1553 

The enums have been accepted since `2021.12` ([PR](https://github.com/home-assistant/core/pull/60720)) which covers your supported versions so it is safe to make immediately, don't have to wait for `2022.4`.