### PR TITLE
Fix Temperature always showing Celsius

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -206,14 +206,18 @@ class TemperatureSensor(SensorEntity, CoordinatorEntity):
         return None
 
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         return TEMP_CELSIUS
 
     @property
-    def state(self):
+    def native_value(self):
         return parse_temperature_from_coordinator(
             self.coordinator, self.alexa_entity_id
         )
+
+    @property
+    def device_class(self):
+        return "temperature"
 
     @property
     def unique_id(self):


### PR DESCRIPTION
Updated Code to add native_unit_of_measurement and device_class. Now the displayed temperature will be as per global  preferences set by user in Settings->System->General