### PR TITLE
Change sensor updating trigger to PUSH_ACTIVITY

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -317,6 +317,12 @@ async def async_setup_entry(hass, config_entry):
         ),
     )
     hass.data[DATA_ALEXAMEDIA]["accounts"][email]["login_obj"] = login
+    no_nt_push_support = ["it"]
+    if any(d in login.url for d in no_nt_push_support):
+        hass.data[DATA_ALEXAMEDIA]["accounts"][email]["notification_push_support"] = False
+        _LOGGER.debug("Amazon region does not support notification_push messages")
+    else:
+        hass.data[DATA_ALEXAMEDIA]["accounts"][email]["notification_push_support"] = True
     if not hass.data[DATA_ALEXAMEDIA]["accounts"][email]["second_account_index"]:
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_alexa_media)
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, complete_startup)
@@ -672,6 +678,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
     async def process_notifications(login_obj, raw_notifications=None):
         """Process raw notifications json."""
         if not raw_notifications:
+            await asyncio.sleep(2)
             raw_notifications = await AlexaAPI.get_notifications(login_obj)
         email: str = login_obj.email
         previous = hass.data[DATA_ALEXAMEDIA]["accounts"][email].get(

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -319,10 +319,14 @@ async def async_setup_entry(hass, config_entry):
     hass.data[DATA_ALEXAMEDIA]["accounts"][email]["login_obj"] = login
     no_nt_push_support = ["it", "de", "com.au"]
     if any(d in login.url for d in no_nt_push_support):
-        hass.data[DATA_ALEXAMEDIA]["accounts"][email]["notification_push_support"] = False
+        hass.data[DATA_ALEXAMEDIA]["accounts"][email][
+            "notification_push_support"
+        ] = False
         _LOGGER.debug("Amazon region does not support notification_push messages")
     else:
-        hass.data[DATA_ALEXAMEDIA]["accounts"][email]["notification_push_support"] = True
+        hass.data[DATA_ALEXAMEDIA]["accounts"][email][
+            "notification_push_support"
+        ] = True
     if not hass.data[DATA_ALEXAMEDIA]["accounts"][email]["second_account_index"]:
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_alexa_media)
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, complete_startup)

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -317,7 +317,7 @@ async def async_setup_entry(hass, config_entry):
         ),
     )
     hass.data[DATA_ALEXAMEDIA]["accounts"][email]["login_obj"] = login
-    no_nt_push_support = ["it", "de"]
+    no_nt_push_support = ["it", "de", "com.au"]
     if any(d in login.url for d in no_nt_push_support):
         hass.data[DATA_ALEXAMEDIA]["accounts"][email]["notification_push_support"] = False
         _LOGGER.debug("Amazon region does not support notification_push messages")
@@ -678,7 +678,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
     async def process_notifications(login_obj, raw_notifications=None):
         """Process raw notifications json."""
         if not raw_notifications:
-            await asyncio.sleep(2)
+            await asyncio.sleep(4)
             raw_notifications = await AlexaAPI.get_notifications(login_obj)
         email: str = login_obj.email
         previous = hass.data[DATA_ALEXAMEDIA]["accounts"][email].get(

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -317,7 +317,7 @@ async def async_setup_entry(hass, config_entry):
         ),
     )
     hass.data[DATA_ALEXAMEDIA]["accounts"][email]["login_obj"] = login
-    no_nt_push_support = ["it"]
+    no_nt_push_support = ["it", "de"]
     if any(d in login.url for d in no_nt_push_support):
         hass.data[DATA_ALEXAMEDIA]["accounts"][email]["notification_push_support"] = False
         _LOGGER.debug("Amazon region does not support notification_push messages")

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -555,7 +555,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
     def _handle_event(self, event):
         """Handle events.
 
-        This will update PUSH_NOTIFICATION_CHANGE and PUSH_ACTIVITY events to see if the sensor
+        This will update PUSH_ACTIVITY events to see if the sensor
         should be updated.
         """
         try:
@@ -563,26 +563,12 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 return
         except AttributeError:
             pass
-        if "notification_update" in event:
+        if "push_activity" in event:
             if (
-                event["notification_update"]["dopplerId"]["deviceSerialNumber"]
+                event["activity_event"]["key"]["serialNumber"]
                 == self._client.device_serial_number
             ):
-                _LOGGER.debug(
-                    "Updating sensor %s from PUSH_NOTIFICATION_CHANGE event", self
-                )
-                self.schedule_update_ha_state(True)
-        elif (
-            "push_activity" in event
-            and not self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._account][
-                "notification_push_support"
-            ]
-        ):
-            if (
-                event["push_activity"]["key"]["serialNumber"]
-                == self._client.device_serial_number
-            ):
-                _LOGGER.debug("Updating sensor %s from PUSH_ACTIVITY event", self)
+                _LOGGER.debug("Updating sensor %s", self)
                 self.schedule_update_ha_state(True)
 
     @property

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -563,17 +563,19 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 return
         except AttributeError:
             pass
-        event_message = "notification_update"
-        event_sn = event[event_message]["dopplerId"]["deviceSerialNumber"] if event.get(event_message) else None
-        if not self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._account]["notification_push_support"]:
-            event_message = "push_activity"
-            event_sn = event[event_message]["key"]["serialNumber"]
-        if event_message in event:
+        if "notification_update" in event:
             if (
-                event_sn
+                event["notification_update"]["dopplerId"]["deviceSerialNumber"]
                 == self._client.device_serial_number
             ):
-                _LOGGER.debug("Updating sensor %s", self)
+                _LOGGER.debug("Updating sensor %s from PUSH_NOTIFICATION_CHANGE event", self)
+                self.schedule_update_ha_state(True)
+        elif "push_activity" in event and not self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._account]["notification_push_support"]:
+            if (
+                event["push_activity"]["key"]["serialNumber"]
+                == self._client.device_serial_number
+            ):
+                _LOGGER.debug("Updating sensor %s from PUSH_ACTIVITY event", self)
                 self.schedule_update_ha_state(True)
 
     @property

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -568,7 +568,9 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 event["notification_update"]["dopplerId"]["deviceSerialNumber"]
                 == self._client.device_serial_number
             ):
-                _LOGGER.debug("Updating sensor %s from PUSH_NOTIFICATION_CHANGE event", self)
+                _LOGGER.debug(
+                    "Updating sensor %s from PUSH_NOTIFICATION_CHANGE event", self
+                )
                 self.schedule_update_ha_state(True)
         elif (
             "push_activity" in event

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -555,7 +555,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
     def _handle_event(self, event):
         """Handle events.
 
-        This will update PUSH_NOTIFICATION_CHANGE events to see if the sensor
+        This will update PUSH_NOTIFICATION_CHANGE and PUSH_ACTIVITY events to see if the sensor
         should be updated.
         """
         try:
@@ -563,9 +563,14 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 return
         except AttributeError:
             pass
-        if "notification_update" in event:
+        event_message = "notification_update"
+        event_sn = event[event_message]["dopplerId"]["deviceSerialNumber"] if event.get(event_message) else None
+        if not self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._account]["notification_push_support"]:
+            event_message = "push_activity"
+            event_sn = event[event_message]["key"]["serialNumber"]
+        if event_message in event:
             if (
-                event["notification_update"]["dopplerId"]["deviceSerialNumber"]
+                event_sn
                 == self._client.device_serial_number
             ):
                 _LOGGER.debug("Updating sensor %s", self)

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -565,7 +565,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
             pass
         if "push_activity" in event:
             if (
-                event["activity_event"]["key"]["serialNumber"]
+                event["push_activity"]["key"]["serialNumber"]
                 == self._client.device_serial_number
             ):
                 _LOGGER.debug("Updating sensor %s", self)

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -570,7 +570,12 @@ class AlexaMediaNotificationSensor(SensorEntity):
             ):
                 _LOGGER.debug("Updating sensor %s from PUSH_NOTIFICATION_CHANGE event", self)
                 self.schedule_update_ha_state(True)
-        elif "push_activity" in event and not self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._account]["notification_push_support"]:
+        elif (
+            "push_activity" in event
+            and not self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._account][
+                "notification_push_support"
+            ]
+        ):
             if (
                 event["push_activity"]["key"]["serialNumber"]
                 == self._client.device_serial_number


### PR DESCRIPTION
Amazon stopped sending `NOTIFICATION_UPDATE` messages (at least for specific accounts, discussion in #1971)

This PR also adds a small delay in order to get updated data from the API.
These changes are proposed to the following accounts:
- amazon.it
- amazon.de
- amazon.com.au

The only current limitation is that Alexa commands must be sent ~10 seconds apart in order to update the sensors, but feedback is greatly appreciated.