### PR TITLE
Restore NOTIFICATION_CHANGE

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -557,7 +557,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
     def _handle_event(self, event):
         """Handle events.
 
-        This will update PUSH_ACTIVITY or NOTIFICATION_UPDATE events to see if 
+        This will update PUSH_ACTIVITY or NOTIFICATION_UPDATE events to see if
         the sensor should be updated.
         """
         try:
@@ -571,7 +571,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
                 == self._client.device_serial_number
             ):
                 _LOGGER.debug("Updating sensor %s", self)
-                self.schedule_update_ha_state(True)            
+                self.schedule_update_ha_state(True)
         if "push_activity" in event:
             if (
                 event["push_activity"]["key"]["serialNumber"]

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -557,14 +557,21 @@ class AlexaMediaNotificationSensor(SensorEntity):
     def _handle_event(self, event):
         """Handle events.
 
-        This will update PUSH_ACTIVITY events to see if the sensor
-        should be updated.
+        This will update PUSH_ACTIVITY or NOTIFICATION_UPDATE events to see if 
+        the sensor should be updated.
         """
         try:
             if not self.enabled:
                 return
         except AttributeError:
             pass
+        if "notification_update" in event:
+            if (
+                event["notification_update"]["dopplerId"]["deviceSerialNumber"]
+                == self._client.device_serial_number
+            ):
+                _LOGGER.debug("Updating sensor %s", self)
+                self.schedule_update_ha_state(True)            
         if "push_activity" in event:
             if (
                 event["push_activity"]["key"]["serialNumber"]


### PR DESCRIPTION
This restores NOTIFICATION_CHANGE events for updating alarms and timers, which Amazon appears to support via HTTP2 notifications. This restores alarm and timer updates via changes in the Alexa app. I've kept PUSH_ACTIVITY as well as there does not seem to be any downside in responding to both event types and Amazon may be inconsistent in their implementation across different regions. 

Partial revert of 8f0dfa2 to restore NOTIFICATION_CHANGE functionality for timers and alarms.